### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Take a look at example project, provided in ShapesExample folder.
 
 * iOS 7,8,9 
 * ARC
-* XCode 7 and iOS 9 SDK
+* Xcode 7 and iOS 9 SDK
 
 ## Installation
 


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
